### PR TITLE
Add LaunchBox parity workflows to the Web UI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,14 +7,14 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report an issue. Please search [existing issues](https://github.com/vindeckyy/OpenBoxGL/issues) first. The current release is [v0.5.0](https://github.com/vindeckyy/OpenBoxGL/releases/latest).
+        Thanks for taking the time to report an issue. Please search [existing issues](https://github.com/vindeckyy/OpenBoxGL/issues) first. The current release is [v0.6.0](https://github.com/vindeckyy/OpenBoxGL/releases/latest).
 
   - type: input
     id: version
     attributes:
       label: OpenBox version
       description: Release tag, AppImage version, or git commit hash
-      placeholder: v0.5.0
+      placeholder: v0.6.0
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Flatpak packages now include the diagnostic logging module.
 
+## [0.6.0] - 2026-07-30
+
+### Added
+
+- LaunchBox-style advanced search in the Web UI, including field terms, quoted values, status filters, and negative terms.
+- Ordered manual playlists with parent grouping, notes, membership editing, and keyboard-friendly reorder controls, alongside existing filter playlists.
+- Game context actions, Ctrl/Shift multi-selection, configurable status badges, richer platform/category/playlist detail panes, related-game reasons, artwork galleries, and per-game launch profile overrides.
+- Backup archive listing, manifest summaries, restore actions, expanded artwork groups, and metadata fields for controller support, disc count, portable games, and broken entries.
+
+### Changed
+
+- State persistence now uses schema migrations, stable game identities with legacy aliases, last-known-good recovery, process-safe transactions, atomic writes, and corruption preservation.
+- Long-running backend jobs now expose bounded state, retries, cancellation, durations, and replacement protection. Request bodies, downloads, archives, media responses, save restores, backup restores, and plugin execution use bounded and validated paths.
+- Packaging uses the runtime module manifest and stricter import and artifact checks. Flatpak support documentation and release validation were refreshed.
+
+### Verification
+
+- Added focused API and launch-profile regression tests.
+- Ran `./run_all_tests.sh`, Python compilation, JavaScript syntax checks, diff validation, and a Chromium smoke test covering the new search, selection, context, playlist, backup, settings, media, and detail workflows.
+
 ## [0.5.0] - 2026-07-30
 
 ### Added
@@ -188,7 +208,8 @@ If you jumped from an older build and skipped the last two releases:
 - Session tracking and plugin hooks
 - AppImage, Flatpak manifest, and Makefile install targets
 
-[Unreleased]: https://github.com/vindeckyy/OpenBoxGL/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/vindeckyy/OpenBoxGL/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/vindeckyy/OpenBoxGL/releases/tag/v0.6.0
 [0.5.0]: https://github.com/vindeckyy/OpenBoxGL/releases/tag/v0.5.0
 [0.4.10]: https://github.com/vindeckyy/OpenBoxGL/releases/tag/v0.4.10
 [0.4.9]: https://github.com/vindeckyy/OpenBoxGL/releases/tag/v0.4.9

--- a/PARITY.md
+++ b/PARITY.md
@@ -1,6 +1,6 @@
 # OpenBox Parity Matrix
 
-OpenBox tracks LaunchBox feature parity for Linux environments. For contribution and release workflow, see [CONTRIBUTING.md](CONTRIBUTING.md) and [CHANGELOG.md](CHANGELOG.md). The latest release is **v0.5.0**, with Steam Game Mode, library and AppImage reliability fixes, local diagnostic logs, Steam-import cleanup, and repaired LaunchBox artwork downloads (see the CHANGELOG).
+OpenBox tracks LaunchBox feature parity for Linux environments. For contribution and release workflow, see [CONTRIBUTING.md](CONTRIBUTING.md) and [CHANGELOG.md](CHANGELOG.md). The latest release is **v0.6.0**, with LaunchBox-style search, playlists, collection details, badges, media groups, backup management, and backend reliability work (see the CHANGELOG).
 
 > **Legal disclaimer:** OpenBox is an independent open-source project and is NOT affiliated, associated, authorized, endorsed by, or in any way officially connected with LaunchBox or Unbroken Software, LLC. Reference to LaunchBox features is solely for software compatibility tracking and open-source parity comparison.
 
@@ -22,7 +22,7 @@ Acceptance source: [LaunchBox product overview](https://www.launchbox-app.com/ab
 | EA, Ubisoft, and Xbox imports | done | Lutris/Heroic catalog import with EA, Ubisoft, and Xbox/Game Pass tagging; Xbox native PC packages remain unavailable on Linux |
 | MAME and FinalBurn full-set imports | done | DAT/XML metadata classifies and imports merged, split, and non-merged sets |
 | LaunchBox Games Database matching | done | Official daily database sync, local matching, and selected metadata/media downloads work |
-| Media manager and image groups | done | Grid image groups, audits, bulk downloads, duplicate cleanup, region priority, and download limits work |
+| Media manager and image groups | done | Grid image groups, extended artwork groups, audits, bulk downloads, duplicate cleanup, region priority, and download limits work |
 | Emulator profiles and per-game commands | done | Commands launch without a shell |
 | Emulator installation and automatic configuration | done | Install, Update All, open emulator, recommend-on-import, and dependency checks work |
 | Archive extraction before launch | done | ZIP uses safe built-in extraction; 7z/RAR use installed 7z |
@@ -33,12 +33,12 @@ Acceptance source: [LaunchBox product overview](https://www.launchbox-app.com/ab
 | Save management | done | Discover, scan, retention limits, versioned backups, backup-on-close, and restore work |
 | RetroAchievements | done | Account, matching, progress, badges, Big Box filters, pause access, and emulator injection work |
 | Video, music, and screenshot playback | done | Multi-category videos, library BGM, video/BGM mix, capture, and gallery work |
-| Playlists, auto-filters, and saved filters | done | Platform, view, and search rules save, apply, update, and delete |
+| Playlists, auto-filters, and saved filters | done | Platform, view, search rules, ordered manual members, parent playlists, and notes save, apply, update, and delete |
 | Big Box controller-first navigation | done | Stage, hybrid, and CoverFlow layouts; filter/sort/RA filters; pause overlay; screensaver launch |
 | Steam Game Mode / gamescope guest | done | `--game-mode` opens Big Box; guest detection; Steam launches keep Input; non-Steam windows get best-effort STEAM_GAME props |
 | Themes and per-platform themes | done | Five stock CSS themes ship with the Web UI; import, persist, apply live, and open-folder access work |
 | Plugin manager and extension API | done | Local packages install and run hooks; curated community catalog is bundled |
-| Backups and restore | done | Restore creates a pre-restore safety copy |
+| Backups and restore | done | The web UI lists archives, shows manifests, restores selected archives, and creates a pre-restore safety copy |
 | Library audit and missing-file checks | done | Files, provider-aware duplicates, media, extras, saves, and emulator configuration are audited |
 | Linux packaging and updates | done | AppImage build, Flatpak manifest, Makefile install/uninstall, desktop entry, and verified update mechanism |
 | Welcome wizard and first-run setup | done | Staged setup wizard with media limits and persistent import queues |
@@ -78,6 +78,11 @@ Acceptance source: [LaunchBox product overview](https://www.launchbox-app.com/ab
 | Big Box shutdown apps on mode switch | done | Configurable commands run when entering or leaving Big Box |
 | Xbox 360 and loose arcade import | done | default.xex folder scan and Hypseus/Singe loose file import |
 | Vita3K title resolution | done | Title IDs resolve to readable game names on import |
+| Advanced search syntax | done | Field terms such as `platform:PC`, quoted values, status terms, and negative terms filter the live grid |
+| Context actions and multi-selection | done | Right-click actions plus Ctrl/Shift range selection expose launch, favorite, progress, playlist, edit, and remove actions |
+| Configurable status badges | done | Settings controls favorite, install, media, save, progress, storefront, achievement, rating, and hardware badges |
+| Collection and related details | done | Platform, category, and playlist detail panes show stats, quick actions, rich related-game reasons, and artwork galleries |
+| Per-game launch profile overrides | done | A game can select an installed emulator profile without changing the platform default |
 
 All LaunchBox Premium-equivalent workflows above are included in OpenBox without a subscription. OpenBox sets `premium_features_free: true` in settings and ships bundled media packs without a license gate.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg" alt="License: AGPL-3.0"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/Python-3.10+-3776AB?logo=python&logoColor=white" alt="Python 3.10+"></a>
-  <a href="https://github.com/vindeckyy/OpenBoxGL/releases/tag/v0.5.0"><img src="https://img.shields.io/badge/Release-v0.5.0-0052CC" alt="Release v0.5.0"></a>
+  <a href="https://github.com/vindeckyy/OpenBoxGL/releases/tag/v0.6.0"><img src="https://img.shields.io/badge/Release-v0.6.0-0052CC" alt="Release v0.6.0"></a>
   <a href="PARITY.md"><img src="https://img.shields.io/badge/LaunchBox-Parity%20Matrix-555" alt="LaunchBox parity matrix"></a>
 </p>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported |
 | --- | --- |
-| 0.5.x | Yes |
+| 0.6.x | Yes |
+| 0.5.x | Best effort |
 | 0.4.x | Best effort |
 | < 0.4.0 | No |
 

--- a/catalog.py
+++ b/catalog.py
@@ -4,7 +4,7 @@ import re
 from datetime import datetime
 
 PROGRESS = {"", "Playing", "Paused", "Beaten", "Completed", "Mastered", "Abandoned"}
-MEDIA_FIELDS = ("cover", "background", "video", "music")
+MEDIA_FIELDS = ("cover", "background", "clear_logo", "fanart", "banner", "icon", "box_back", "box_spine", "box_3d", "title_screen", "video", "music")
 
 
 def related_game_ids(games, selected, limit=8):

--- a/index.html
+++ b/index.html
@@ -200,6 +200,25 @@
     .primary { border:0; border-radius:4px; padding:8px 16px; background:#21aeda; color:#07131a; font-weight:800; }
     .toast { position:fixed; z-index:20; right:18px; bottom:18px; max-width:360px; padding:11px 14px; border:1px solid #495169; border-radius:6px; background:#202638; color:#fff; box-shadow:0 12px 30px #0009; opacity:0; transform:translateY(8px); pointer-events:none; transition:.2s; }
     .toast.show { opacity:1; transform:none; }
+    .context-menu { position:fixed; z-index:60; width:min(280px,calc(100vw - 20px)); padding:6px; border:1px solid #4a536b; border-radius:7px; background:#171d2c; box-shadow:0 18px 50px #000c; }
+    .context-menu[hidden] { display:none; }
+    .context-menu button,.context-menu select { width:100%; margin:2px 0; }
+    .context-menu button { text-align:left; }
+    .badge-row { display:flex; flex-wrap:wrap; gap:4px; min-height:18px; }
+    .badge { display:inline-flex; align-items:center; gap:3px; padding:2px 5px; border:1px solid #3e4961; border-radius:4px; color:#c8d1e2; background:#20283a; font-size:9px; line-height:1.2; }
+    .badge.favorite,.badge.progress { color:#f2c34a; }
+    .badge.danger { color:#ff9d9d; border-color:#78404b; }
+    .collection-summary { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-top:12px; }
+    .collection-stat { padding:9px; border:1px solid #30374a; border-radius:6px; background:#1c2131; }
+    .collection-stat small,.collection-stat strong { display:block; }
+    .collection-stat small { color:#7f899f; font-size:9px; text-transform:uppercase; }
+    .collection-stat strong { margin-top:2px; font-size:16px; }
+    .playlist-manager-list,.backup-list { display:grid; gap:8px; max-height:55vh; overflow:auto; }
+    .playlist-manager-item,.backup-item { display:grid; grid-template-columns:minmax(0,1fr) auto; gap:10px; align-items:center; padding:10px; border:1px solid #30374a; border-radius:7px; background:#1c2131; }
+    .playlist-manager-item small,.backup-item small { display:block; color:#7f899f; }
+    .playlist-manager-actions { display:flex; flex-wrap:wrap; gap:5px; justify-content:flex-end; }
+    .member-list { display:grid; gap:4px; margin-top:7px; }
+    .member-row { display:grid; grid-template-columns:minmax(0,1fr) auto auto; gap:4px; align-items:center; }
     .lifecycle { position:fixed; z-index:40; inset:0; display:grid; place-items:center; text-align:center; background:radial-gradient(circle at 50% 42%,var(--lifecycle-bg),#080b12 70%); }
     .lifecycle[hidden] { display:none; }
     .lifecycle small { color:var(--lifecycle-kicker); font-size:12px; font-weight:800; letter-spacing:.2em; text-transform:uppercase; }
@@ -318,6 +337,7 @@
     <button class="menu-button" id="themesButton">Themes</button>
     <button class="menu-button" id="saveFilterButton">Save Filter</button>
     <button class="menu-button" id="savePresetButton">Save Preset</button>
+    <button class="menu-button" id="playlistsButton">Playlists</button>
     <button class="menu-button" id="achievementsButton">Achievements</button>
     <button class="menu-button" id="pluginsButton">Plugins</button>
     <button class="menu-button" id="discoveryButton">Discovery</button>
@@ -351,7 +371,7 @@
       <div class="library-head">
         <div><h1 id="libraryTitle">All Games</h1><p id="libraryMeta">0 games</p></div>
         <select class="search" id="sort" aria-label="Sort games"><option value="title">Title</option><option value="rating">Rating</option><option value="recent">Recently played</option><option value="recent_activity">Recent activity</option><option value="playtime">Play time</option><option value="added">Date added</option><option value="platform">Platform</option><option value="genre">Genre</option></select>
-        <select class="search" id="imageGroup" aria-label="Image group"><option value="default">Use default</option><option value="cover">Box fronts</option><option value="background">Backgrounds</option><option value="screenshot">Screenshots</option></select>
+        <select class="search" id="imageGroup" aria-label="Image group"><option value="default">Use default</option><option value="cover">Box fronts</option><option value="background">Backgrounds</option><option value="screenshot">Screenshots</option><option value="clear_logo">Clear logos</option><option value="fanart">Fanart</option><option value="banner">Banners</option><option value="box_back">Box backs</option><option value="box_spine">Box spines</option><option value="box_3d">3D boxes</option><option value="title_screen">Title screens</option></select>
         <button class="icon-button" id="viewToggleButton">List view</button>
         <button class="icon-button" id="surpriseButton">Surprise me</button>
       </div>
@@ -395,12 +415,25 @@
         <label class="field wide"><span>Background image path</span><input name="background"></label>
         <label class="field wide"><span>Video path</span><input name="video"></label>
         <label class="field wide"><span>Music path</span><input name="music"></label>
+        <label class="field"><span>Controller support</span><input name="controller_support" placeholder="Gamepad, keyboard"></label>
+        <label class="field"><span>Disc count</span><input name="disc_count" type="number" min="0" max="99"></label>
+        <label class="field wide"><span>Clear logo path</span><input name="clear_logo"></label>
+        <label class="field wide"><span>Fanart path</span><input name="fanart"></label>
+        <label class="field wide"><span>Banner path</span><input name="banner"></label>
+        <label class="field wide"><span>Icon path</span><input name="icon"></label>
+        <label class="field wide"><span>Box back path</span><input name="box_back"></label>
+        <label class="field wide"><span>Box spine path</span><input name="box_spine"></label>
+        <label class="field wide"><span>3D box path</span><input name="box_3d"></label>
+        <label class="field wide"><span>Title screen path</span><input name="title_screen"></label>
         <label class="field wide"><span>Screenshot paths, one per line</span><textarea name="screenshots"></textarea></label>
         <label class="field wide"><span>RetroAchievements Game ID, optional manual match</span><input name="ra_game_id" inputmode="numeric"></label>
-        <label class="field wide"><span>Launch command</span><input name="launch"></label>
+        <label class="field wide"><span>Launch command, optional override</span><input name="launch"></label>
+        <label class="field wide"><span>Launch profile override</span><select name="launch_profile"><option value="">Default platform profile</option></select></label>
         <label class="check"><input type="checkbox" name="extract_archive">Extract archive before launch</label>
         <label class="check"><input type="checkbox" name="hide_in_bigbox"> Hide in Big Box</label>
         <label class="check"><input type="checkbox" name="hidden">Hide from normal views</label>
+        <label class="check"><input type="checkbox" name="broken"> Mark as broken</label>
+        <label class="check"><input type="checkbox" name="portable"> Mark as portable</label>
         <label class="field"><span>Archive member</span><input name="archive_member"></label>
         <label class="field wide"><span>Additional applications, one per line: Name | Path | Command</span><textarea name="applications"></textarea></label>
         <label class="field wide"><span>Alternate versions, one per line: Name | Path | Command</span><textarea name="versions"></textarea></label>
@@ -516,6 +549,24 @@
       <div class="dialog-actions"><button type="button" class="icon-button" id="cancelBulk">Cancel</button><button class="primary">Apply</button></div>
     </form>
   </dialog>
+  <dialog id="playlistsDialog">
+    <div class="dialog-head"><h2>Playlists</h2><button type="button" id="closePlaylists" aria-label="Close Playlists dialog">×</button></div>
+    <div class="form-grid">
+      <div class="wide extras"><button type="button" class="primary" id="newManualPlaylist">New manual playlist</button><button type="button" class="icon-button" id="newFilterPlaylist">New filter playlist</button></div>
+      <div class="wide description">Manual playlists keep an ordered set of games. Filter playlists update from their rules.</div>
+      <div class="wide playlist-manager-list" id="playlistManagerList"></div>
+    </div>
+    <div class="dialog-actions"><button type="button" class="primary" id="donePlaylists">Done</button></div>
+  </dialog>
+  <dialog id="backupDialog">
+    <div class="dialog-head"><h2>Backups</h2><button type="button" id="closeBackups" aria-label="Close Backups dialog">×</button></div>
+    <div class="form-grid">
+      <div class="wide extras"><button type="button" class="primary" id="createNamedBackup">Create backup</button><button type="button" class="icon-button" id="refreshBackups">Refresh</button></div>
+      <div class="wide description">Backups include selected library data, settings, media, plugins, and themes. Restore creates a safety copy first.</div>
+      <div class="wide backup-list" id="backupList"></div>
+    </div>
+    <div class="dialog-actions"><button type="button" class="primary" id="doneBackups">Done</button></div>
+  </dialog>
   <dialog id="sessionsDialog">
     <div class="dialog-head"><h2>Running Games</h2><button type="button" id="closeSessions" aria-label="Close Running Games dialog">×</button></div>
     <div class="form-grid"><div class="wide emulator-list" id="sessionList"></div></div>
@@ -554,7 +605,23 @@
         <div class="wide settings-field" data-setting="diagnostic support troubleshooting logs"><button type="button" class="icon-button" id="copyDiagnosticLog">Copy diagnostic log</button><span class="description">Review it before sharing because it can include game names and local file paths.</span></div>
         <label class="field wide settings-field" data-setting="cloud sync syncthing dropbox nextcloud"><span>Mounted Nextcloud, Syncthing, Dropbox, or other cloud folder for game-stat syncing</span><input id="cloudFolder"></label>
         <div class="wide settings-field" data-setting="cloud sync"><button type="button" class="icon-button" id="syncCloud">Sync statistics now</button><span class="description" id="cloudStatus"></span></div>
-        <label class="field wide settings-field" data-setting="default image group viewing cover background screenshot"><span>Default image group</span><select id="defaultImageGroup"><option value="cover">Box fronts</option><option value="background">Backgrounds</option><option value="screenshot">Screenshots</option></select></label>
+        <label class="field wide settings-field" data-setting="default image group viewing cover background screenshot clear logo fanart banner icon box back box spine 3d box title screen"><span>Default image group</span><select id="defaultImageGroup"><option value="cover">Box fronts</option><option value="background">Backgrounds</option><option value="screenshot">Screenshots</option><option value="clear_logo">Clear logos</option><option value="fanart">Fanart</option><option value="banner">Banners</option><option value="icon">Icons</option><option value="box_back">Box backs</option><option value="box_spine">Box spines</option><option value="box_3d">3D boxes</option><option value="title_screen">Title screens</option></select></label>
+        <div class="wide settings-field" data-setting="badges favorite installed missing media saves documents versions storefront achievements high scores progress rating broken portable controller"><span>Visible game badges</span><div class="badge-row">
+          <label class="check"><input type="checkbox" data-badge-setting="favorite"> Favorite</label>
+          <label class="check"><input type="checkbox" data-badge-setting="installed"> Installed</label>
+          <label class="check"><input type="checkbox" data-badge-setting="missing_media"> Missing media</label>
+          <label class="check"><input type="checkbox" data-badge-setting="saves"> Saves</label>
+          <label class="check"><input type="checkbox" data-badge-setting="documents"> Documents</label>
+          <label class="check"><input type="checkbox" data-badge-setting="versions"> Versions</label>
+          <label class="check"><input type="checkbox" data-badge-setting="storefront"> Storefront</label>
+          <label class="check"><input type="checkbox" data-badge-setting="achievements"> Achievements</label>
+          <label class="check"><input type="checkbox" data-badge-setting="highscores"> High scores</label>
+          <label class="check"><input type="checkbox" data-badge-setting="progress"> Progress</label>
+          <label class="check"><input type="checkbox" data-badge-setting="rating"> Rating</label>
+          <label class="check"><input type="checkbox" data-badge-setting="broken"> Broken</label>
+          <label class="check"><input type="checkbox" data-badge-setting="portable"> Portable</label>
+          <label class="check"><input type="checkbox" data-badge-setting="controller"> Controller</label>
+        </div></div>
         <label class="field wide settings-field" data-setting="screensaver big box attract"><span>Big Box screensaver delay in seconds, 0 disables it</span><input id="screensaverSeconds" type="number" min="0" max="3600"></label>
         <label class="field wide settings-field" data-setting="startup applications commands"><span>Applications to start with OpenBox, one shell-free command per line</span><textarea id="startupCommands"></textarea></label>
         <label class="field wide settings-field" data-setting="shutdown applications commands exit"><span>Applications to start when OpenBox exits, one shell-free command per line</span><textarea id="shutdownCommands"></textarea></label>
@@ -644,6 +711,16 @@
     <div class="reader-viewport" id="readerViewport"><iframe id="readerFrame" title="Document reader"></iframe></div>
   </dialog>
   <div class="toast" id="toast"></div>
+  <div class="context-menu" id="contextMenu" hidden>
+    <button type="button" class="icon-button" id="contextPlay">Play</button>
+    <button type="button" class="icon-button" id="contextFavorite">Toggle favorite</button>
+    <button type="button" class="icon-button" id="contextEdit">Edit metadata</button>
+    <button type="button" class="icon-button" id="contextProgress">Mark progress</button>
+    <select id="contextPlaylist" aria-label="Playlist"><option value="">Add to playlist...</option></select>
+    <button type="button" class="icon-button" id="contextAddPlaylist">Add selected game</button>
+    <button type="button" class="icon-button" id="contextNewPlaylist">New playlist from game</button>
+    <button type="button" class="icon-button" id="contextRemove">Remove from library</button>
+  </div>
   <section class="lifecycle" id="lifecycle" hidden><div><small id="lifecycleKind"></small><h2 id="lifecycleGame"></h2><p id="lifecycleMessage"></p></div></section>
   <section class="bigbox" id="bigBox" hidden tabindex="0">
     <video class="bigbox-startup-video" id="bigBoxStartupVideo" muted loop playsinline hidden></video>
@@ -666,7 +743,7 @@
 
   <script>
     const token = new URLSearchParams(location.search).get('token') || '';
-    let games = [], playlists = [], filterPresets = [], explorerField = 'genre', explorerRules = {}, activeFilterPreset = '', bigBoxGames = [], runningGames = [], raConfigured = false, selectedId = null, platform = 'all', activePlaylist = '', editingId = null, metadataGameId = null, bigBoxIndex = 0, gamepadState = {}, lastSessionEvent = 0, bulkMode = false, bigBoxLastInput = performance.now(), screenSaverGame = null;
+    let games = [], playlists = [], filterPresets = [], explorerField = 'genre', explorerRules = {}, activeFilterPreset = '', bigBoxGames = [], runningGames = [], raConfigured = false, selectedId = null, platform = 'all', activePlaylist = '', editingId = null, metadataGameId = null, bigBoxIndex = 0, gamepadState = {}, lastSessionEvent = 0, bulkMode = false, bigBoxLastInput = performance.now(), screenSaverGame = null, contextGameId = null, availableProfiles = {};
     let appSettings = {watch_folders:[],screensaver_seconds:90,controller_map:{},library_view:'grid',locale:'en'}, bigBoxFilter = 'all', bigBoxSort = 'title', bigBoxRaFilter = 'all', bigBoxPlatform = 'all', platformCategory = 'all', pendingUpdate = null, duplicateMediaGroups = 0, libraryBgm = null, readerPage = 1, readerUrl = '', bigBoxHybridQuery = '';
     const defaultControllerMap = {play:0,back:1,favorite:2,random:3,page_left:4,page_right:5,pause:8,menu:9};
     const selectedIds = new Set();
@@ -674,6 +751,72 @@
     const escapeHtml = value => String(value ?? '').replace(/[&<>"']/g, char => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[char]));
     const media = (game, kind, index = '') => `/api/media?id=${game.id}&kind=${kind}${index === '' ? '' : `&index=${index}`}&token=${encodeURIComponent(token)}`;
     const duration = seconds => { const minutes = Math.floor((seconds || 0) / 60), hours = Math.floor(minutes / 60); return hours ? `${hours}h ${minutes % 60}m` : `${minutes}m`; };
+    const defaultBadges = ['favorite','installed','saves','documents','progress','storefront','achievements','rating'];
+    const badgeVisibility = () => new Set(appSettings.badge_visibility || defaultBadges);
+    const gameInstalled = game => game.store_installed !== false && (game.path_exists || game.store_installed);
+    const playlistFor = name => playlists.find(item => item.name === name);
+    const playlistMembers = playlist => new Set((playlist?.members || []).map(String));
+    const gameInPlaylist = (game, playlist) => {
+      if (!playlist) return false;
+      if (playlist.type !== 'manual') return true;
+      return playlistMembers(playlist).has(String(game.game_id)) || playlistMembers(playlist).has(String(game.id));
+    };
+    const formatBytes = value => { const bytes = Number(value || 0); return bytes > 1024 * 1024 ? `${(bytes / 1024 / 1024).toFixed(1)} MB` : `${Math.max(1, Math.round(bytes / 1024))} KB`; };
+    function advancedQueryMatches(game, query) {
+      const tokens = String(query || '').match(/(?:[^\s"]+:"[^"]*"|[^\s]+|"[^"]*")+/g) || [];
+      const fields = {
+        title:['name','sort_title','alternate_names'], platform:['platform'], plat:['platform'], genre:['genre'],
+        dev:['developer'], developer:['developer'], pub:['publisher'], publisher:['publisher'], series:['series'],
+        region:['region'], play:['play_mode'], playmode:['play_mode'], notes:['notes'], source:['source'],
+        store:['source'], storefront:['source'], status:['status'], progress:['progress'], rating:['rating'],
+        favorite:['favorite'], fav:['favorite'], installed:['installed'], hide:['hidden'], hidden:['hidden'],
+        broken:['broken'], portable:['portable'], controller:['controller_support'], all:['name','sort_title','alternate_names','platform','genre','developer','publisher','series','region','notes','source','play_mode','status','progress','controller_support']
+      };
+      const valueFor = (key, names) => {
+        const values = names.flatMap(name => Array.isArray(game[name]) ? game[name] : [game[name]]).filter(value => value !== undefined && value !== null && value !== '');
+        if (key === 'installed') values.push(gameInstalled(game) ? 'yes' : 'no');
+        if (key === 'favorite' || key === 'fav') values.push(game.favorite ? 'yes' : 'no');
+        if (key === 'hide' || key === 'hidden') values.push(game.hidden ? 'yes' : 'no');
+        if (key === 'broken') values.push(game.broken ? 'yes' : 'no');
+        if (key === 'portable') values.push(game.portable ? 'yes' : 'no');
+        return values.map(value => String(value).toLowerCase());
+      };
+      return tokens.every(token => {
+        const negative = token.startsWith('-');
+        const raw = negative ? token.slice(1) : token;
+        const separator = raw.indexOf(':');
+        const key = separator > 0 ? raw.slice(0, separator).toLowerCase() : 'title';
+        const value = (separator > 0 ? raw.slice(separator + 1) : raw).replace(/^"|"$/g, '').toLowerCase();
+        const names = fields[key] || fields.all;
+        const matched = valueFor(key, names).some(item => item.includes(value));
+        return negative ? !matched : matched;
+      });
+    }
+    function badge(label, value, kind = '') { return value ? `<span class="badge ${kind}" title="${escapeHtml(label)}">${escapeHtml(label)}</span>` : ''; }
+    function renderBadges(game) {
+      const visible = badgeVisibility();
+      return [
+        visible.has('favorite') && badge('Favorite', game.favorite, 'favorite'),
+        visible.has('installed') && badge(gameInstalled(game) ? 'Installed' : 'Owned', true),
+        visible.has('missing_media') && badge('Missing media', game.has_missing_media, 'danger'),
+        visible.has('saves') && badge('Saves', game.has_saves),
+        visible.has('documents') && badge('Docs', game.has_documents),
+        visible.has('versions') && badge('Versions', game.has_versions),
+        visible.has('storefront') && badge(game.source || 'Storefront', Boolean(game.source)),
+        visible.has('achievements') && badge('Achievements', game.has_achievements),
+        visible.has('highscores') && badge('High scores', game.has_highscores),
+        visible.has('progress') && badge(game.progress, Boolean(game.progress), 'progress'),
+        visible.has('rating') && badge(`${game.rating} stars`, Number(game.rating) > 0),
+        visible.has('broken') && badge('Broken', game.broken, 'danger'),
+        visible.has('portable') && badge('Portable', game.portable),
+        visible.has('controller') && badge(game.controller_support, Boolean(game.controller_support)),
+      ].filter(Boolean).join('');
+    }
+    const artworkKinds = [['clear_logo','Clear logo','has_clear_logo'],['fanart','Fanart','has_fanart'],['banner','Banner','has_banner'],['icon','Icon','has_icon'],['box_back','Box back','has_box_back'],['box_spine','Box spine','has_box_spine'],['box_3d','3D box','has_box_3d'],['title_screen','Title screen','has_title_screen']];
+    function renderArtwork(game) {
+      const items = artworkKinds.filter(([, , flag]) => game[flag]);
+      return items.length ? `<div class="detail-card"><h3>Artwork</h3><div class="screenshot-grid">${items.map(([kind,label]) => `<button data-artwork="${kind}" aria-label="Open ${escapeHtml(label)}"><img src="${media(game,kind)}" alt="${escapeHtml(label)}" loading="lazy" decoding="async"></button>`).join('')}</div></div>` : '';
+    }
 
     async function api(path, options = {}) {
       let response;
@@ -705,6 +848,7 @@
       applySidebarVisibility();
       applyLocaleStrings();
       maybeShowWelcome();
+      api('/api/profiles').then(result => { availableProfiles = result.profiles || {}; }).catch(() => {});
       loadExplorerFacets().catch(() => {});
     }
     function applyLocaleStrings() {
@@ -745,9 +889,10 @@
       const view = $('view').value;
       const preset = filterPresets.find(item => item.name === activeFilterPreset);
       const presetRules = preset?.rules || {};
+      const activePlaylistData = playlistFor(activePlaylist);
       const visible = games.filter(game => {
         const completed = ['Beaten','Completed','Mastered'].includes(game.progress);
-        const installed = game.store_installed !== false && (game.path_exists || game.store_installed);
+        const installed = gameInstalled(game);
         const ownedUninstalled = Boolean(game.owned || game.store_catalog || game.gameyfin_id) && !installed;
         const effectiveView = presetRules.view || view;
         const viewMatch = (effectiveView === 'all' && !game.hidden) || (effectiveView === 'favorites' && game.favorite && !game.hidden) || (effectiveView === 'recent' && game.last_played && !game.hidden) || (effectiveView === 'never' && !game.play_count && !game.hidden) || (effectiveView === 'playing' && ['Playing','Paused'].includes(game.progress) && !game.hidden) || (effectiveView === 'completed' && completed && !game.hidden) || (effectiveView === 'installed' && installed && !game.hidden) || (effectiveView === 'owned' && ownedUninstalled && !game.hidden) || (effectiveView === 'saves' && game.has_saves && !game.hidden) || (effectiveView === 'hidden' && game.hidden) || (effectiveView === 'missing' && !game.path_exists && !game.hidden);
@@ -757,8 +902,8 @@
         const categoryMatch = category === 'all' || platformCategoryFor(game) === category;
         const esrb = presetRules.esrb || $('esrbFilter')?.value || '';
         const esrbMatch = !esrb || (game.esrb || 'Unrated') === esrb;
-        const effectiveQuery = (presetRules.query || query).toLowerCase().trim();
-        const queryMatch = !effectiveQuery || [game.name,game.sort_title,game.platform,game.genre,game.developer,game.publisher,game.series,game.region,game.notes,...(game.alternate_names || []),...(Object.values(game.custom_fields || {}))].join(' ').toLowerCase().includes(effectiveQuery);
+        const effectiveQuery = (presetRules.query || query).trim();
+        const queryMatch = !effectiveQuery || advancedQueryMatches(game, effectiveQuery);
         const progressMatch = !presetRules.progress || game.progress === presetRules.progress;
         const favoriteMatch = presetRules.favorite === undefined || Boolean(game.favorite) === Boolean(presetRules.favorite);
         const genreMatch = !presetRules.genre || String(game.genre || '').toLowerCase().includes(String(presetRules.genre).toLowerCase());
@@ -770,7 +915,8 @@
           || installedRule === 'installed' && installed
           || installedRule === 'uninstalled' && !installed;
         const hiddenMatch = presetRules.hidden === undefined || Boolean(game.hidden) === Boolean(presetRules.hidden);
-        return viewMatch && platformMatch && categoryMatch && esrbMatch && queryMatch && progressMatch && explorerProgressMatch && favoriteMatch && genreMatch && developerMatch && publisherMatch && installedMatch && hiddenMatch;
+        const playlistMatch = !activePlaylistData || gameInPlaylist(game, activePlaylistData);
+        return viewMatch && platformMatch && categoryMatch && esrbMatch && queryMatch && progressMatch && explorerProgressMatch && favoriteMatch && genreMatch && developerMatch && publisherMatch && installedMatch && hiddenMatch && playlistMatch;
       });
       return sortGames(visible, $('sort').value);
     }
@@ -830,14 +976,14 @@
       document.querySelectorAll('[data-platform]').forEach(button => button.onclick = () => { activePlaylist = ''; platform = button.dataset.platform; selectedId = null; render(); loadTheme(); });
     }
     function renderPlaylists() {
-      $('playlists').innerHTML = playlists.length ? playlists.map(item => `<div class="playlist-row"><button class="platform ${activePlaylist === item.name ? 'active' : ''}" data-playlist="${escapeHtml(item.name)}">${escapeHtml(item.name)}</button><button class="playlist-delete" data-delete-playlist="${escapeHtml(item.name)}" aria-label="Delete ${escapeHtml(item.name)}">×</button></div>`).join('') : '<span class="description">Save a filter to create one.</span>';
+      $('playlists').innerHTML = playlists.length ? playlists.map(item => `<div class="playlist-row"><button class="platform ${activePlaylist === item.name ? 'active' : ''}" data-playlist="${escapeHtml(item.name)}">${escapeHtml(item.name)} <small>${item.type === 'manual' ? `(${(item.members || []).length})` : '↻'}</small></button><button class="playlist-delete" data-delete-playlist="${escapeHtml(item.name)}" aria-label="Delete ${escapeHtml(item.name)}">×</button></div>`).join('') : '<span class="description">Create a playlist to pin one here.</span>';
       document.querySelectorAll('[data-playlist]').forEach(button => button.onclick = () => {
         const item = playlists.find(playlist => playlist.name === button.dataset.playlist);
         if (!item) return;
         activePlaylist = item.name;
         platform = item.rules.platform || 'all';
         $('view').value = [...$('view').options].some(option => option.value === item.rules.view) ? item.rules.view : 'all';
-        $('sidebarSearch').value = item.rules.query || '';
+        $('sidebarSearch').value = item.type === 'manual' ? '' : item.rules.query || '';
         render();
         loadTheme();
       });
@@ -915,6 +1061,16 @@
       });
       renderDetails();
     }
+    function imageMarkup(game, imageGroup) {
+      const flags = {cover:'has_cover',background:'has_background',screenshot:'available_screenshots',clear_logo:'has_clear_logo',fanart:'has_fanart',banner:'has_banner',icon:'has_icon',box_back:'has_box_back',box_spine:'has_box_spine',box_3d:'has_box_3d',title_screen:'has_title_screen'};
+      const flag = flags[imageGroup];
+      const available = imageGroup === 'screenshot' ? game.available_screenshots?.length : game[flag];
+      if (available) {
+        const index = imageGroup === 'screenshot' ? game.available_screenshots[0] : '';
+        return `<img src="${media(game,imageGroup,index)}" alt="" loading="lazy" decoding="async">`;
+      }
+      return `<div class="cover-title">${escapeHtml(game.name)}</div>`;
+    }
     function renderGrid() {
       const visible = filteredGames();
       const explicitImageGroup = activePlaylist ? appSettings.image_group_by_playlist?.[activePlaylist] : platform !== 'all' ? appSettings.image_group_by_platform?.[platform] : appSettings.image_group;
@@ -933,20 +1089,28 @@
       }
       if ((appSettings.library_view || 'grid') === 'list') {
         $('grid').className = 'list-view';
-        $('grid').innerHTML = `<div class="list-head"><span>Title</span><span>Platform</span><span>Genre</span><span>ESRB</span><span>Progress</span><span>Plays</span><span>Rating</span></div>${visible.map(game => `<button type="button" class="list-row ${selectedId === game.id || selectedIds.has(game.id) ? 'selected' : ''}" data-game="${game.id}" aria-label="Open ${escapeHtml(game.name)}"><strong>${escapeHtml(game.name)}</strong><span>${escapeHtml(game.platform || '')}</span><span>${escapeHtml(game.genre || '')}</span><span>${escapeHtml(game.esrb || '-')}</span><span>${escapeHtml(game.progress || '')}</span><span>${game.play_count || 0}</span><span>${game.rating || ''}</span></button>`).join('')}`;
+        $('grid').innerHTML = `<div class="list-head"><span>Title</span><span>Platform</span><span>Genre</span><span>ESRB</span><span>Progress</span><span>Plays</span><span>Rating</span></div>${visible.map(game => `<button type="button" class="list-row ${selectedId === game.id || selectedIds.has(game.id) ? 'selected' : ''}" data-game="${game.id}" aria-label="Open ${escapeHtml(game.name)}"><strong>${escapeHtml(game.name)}<span class="badge-row">${renderBadges(game)}</span></strong><span>${escapeHtml(game.platform || '')}</span><span>${escapeHtml(game.genre || '')}</span><span>${escapeHtml(game.esrb || '-')}</span><span>${escapeHtml(game.progress || '')}</span><span>${game.play_count || 0}</span><span>${game.rating || ''}</span></button>`).join('')}`;
       } else {
         $('grid').className = 'grid';
         $('grid').innerHTML = visible.map(game => `<article class="card ${selectedId === game.id || selectedIds.has(game.id) ? 'selected' : ''}">
         ${bulkMode ? `<input class="card-picker" type="checkbox" data-game-picker="${game.id}" ${selectedIds.has(game.id) ? 'checked' : ''} aria-label="Select ${escapeHtml(game.name)}">` : ''}
-        <button type="button" class="card-main" data-game="${game.id}" aria-label="Open ${escapeHtml(game.name)}"><div class="cover ${appSettings.bigbox_mode === 'coverflow' ? 'jewel-3d' : ''}">${imageGroup === 'background' && game.has_background ? `<img src="${media(game,'background')}" alt="" loading="lazy" decoding="async">` : imageGroup === 'screenshot' && game.available_screenshots.length ? `<img src="${media(game,'screenshot',game.available_screenshots[0])}" alt="" loading="lazy" decoding="async">` : game.has_cover ? `<img src="${media(game,'cover')}" alt="" loading="lazy" decoding="async">` : `<div class="cover-title">${escapeHtml(game.name)}</div>`}</div>
+        <button type="button" class="card-main" data-game="${game.id}" aria-label="Open ${escapeHtml(game.name)}"><div class="cover ${appSettings.bigbox_mode === 'coverflow' ? 'jewel-3d' : ''}">${imageMarkup(game,imageGroup)}</div>
         <h3>${escapeHtml(game.name)}</h3><p>${escapeHtml(game.developer || game.platform || '')}</p>
-        <div class="badges">${game.favorite ? '★ ' : ''}${game.has_saves ? '💾 ' : ''}${game.has_documents ? '📄 ' : ''}${game.rating ? `${'★'.repeat(Math.round(game.rating))} ` : ''}${game.progress ? escapeHtml(game.progress) : game.play_count ? `${game.play_count}×` : ''}</div></button>
+        <div class="badge-row">${renderBadges(game)}</div></button>
       </article>`).join('');
       }
       document.querySelectorAll('[data-game]').forEach(card => card.onclick = event => {
         const id = Number(card.dataset.game);
-        if (bulkMode) {
-          selectedIds.has(id) ? selectedIds.delete(id) : selectedIds.add(id);
+        if (event.shiftKey || event.ctrlKey || event.metaKey || bulkMode) {
+          if (event.shiftKey && selectedId !== null) {
+            const ids = visible.map(game => game.id);
+            const start = ids.indexOf(selectedId), end = ids.indexOf(id);
+            if (start >= 0 && end >= 0) ids.slice(Math.min(start,end), Math.max(start,end) + 1).forEach(value => selectedIds.add(value));
+          } else {
+            selectedIds.has(id) ? selectedIds.delete(id) : selectedIds.add(id);
+          }
+          selectedId = id;
+          if (!bulkMode) { bulkMode = true; notify('Selection mode enabled. Use Bulk Edit to apply changes.'); }
           renderGrid();
         } else {
           selectGame(id);
@@ -961,25 +1125,28 @@
     }
     function renderDetails() {
       const game = games.find(item => item.id === selectedId);
-      if (!game && platform !== 'all') {
-        renderPlatformDetails(platform);
+      if (!game && (platform !== 'all' || platformCategory !== 'all' || activePlaylist)) {
+        if (activePlaylist) renderCollectionDetails(activePlaylist, filteredGames(), 'Playlist');
+        else if (platformCategory !== 'all') renderCollectionDetails(platformCategory, games.filter(item => platformCategoryFor(item) === platformCategory), 'Category');
+        else renderPlatformDetails(platform);
         return;
       }
       if (!game) { $('details').innerHTML = '<div class="detail-empty">Select a game to inspect its real metadata and artwork.</div>'; return; }
       const heroStyle = game.has_background ? `style="background-image:url('${media(game,'background')}')"` : '';
       $('details').innerHTML = `<div class="hero" ${heroStyle}><div class="hero-copy"><div class="hero-kicker">${escapeHtml(game.platform || 'Unspecified platform')}</div><h2>${escapeHtml(game.name)}</h2></div></div>
         <div class="detail-body">
-          <div class="rating"><strong>${game.favorite ? '★ Favorite' : game.rating ? `${game.rating} ★` : 'Library'}</strong><span>${escapeHtml(game.progress || game.genre || '')}</span></div>
+          <div class="rating"><strong>${game.favorite ? '★ Favorite' : game.rating ? `${game.rating} ★` : 'Library'}</strong><span>${escapeHtml(game.progress || game.genre || '')}</span><span class="badge-row">${renderBadges(game)}</span></div>
           <button class="play" id="playButton" ${game.path_exists && game.store_installed !== false ? '' : game.gameyfin_id && !game.store_installed ? '' : 'disabled'}>${game.gameyfin_id && !game.store_installed ? '⬇ INSTALL' : '▶ PLAY'}</button>
           <div class="detail-actions"><button class="icon-button" id="favoriteButton">${game.favorite ? 'Remove favorite' : 'Add favorite'}</button><button class="icon-button" id="editButton">Edit metadata</button><button class="icon-button" id="databaseMetadataButton">Find metadata</button>${game.steam_app_id ? '<button class="icon-button" id="steamMetadataButton">Use Steam data</button>' : ''}<button class="icon-button" id="captureScreenshot">Capture screenshot</button><button class="icon-button" id="downloadBezel">Download bezel</button>${game.gameyfin_id && game.store_installed ? '<button class="icon-button" id="uninstallGameyfin">Uninstall Gameyfin copy</button>' : ''}<button class="icon-button" id="removeGameButton">Remove game</button></div>
           <div class="detail-card"><h3>Information</h3><div class="facts">
-            ${fact('Release date',game.year)}${fact('Developer',game.developer)}${fact('Publisher',game.publisher)}${fact('ESRB',game.esrb)}${fact('Category',platformCategoryFor(game))}${Object.entries(game.custom_fields || {}).map(([key,value]) => fact(key,value)).join('')}${fact('Max players',game.max_players)}${fact('Play time',duration(game.playtime_seconds))}
+            ${fact('Release date',game.year)}${fact('Developer',game.developer)}${fact('Publisher',game.publisher)}${fact('ESRB',game.esrb)}${fact('Source',game.source)}${fact('Category',platformCategoryFor(game))}${Object.entries(game.custom_fields || {}).map(([key,value]) => fact(key,value)).join('')}${fact('Max players',game.max_players)}${fact('Controller support',game.controller_support)}${fact('Disc count',game.disc_count)}${fact('Play time',duration(game.playtime_seconds))}
             ${fact('Launches',game.play_count)}${fact('Last played',game.last_played ? game.last_played.replace('T',' ') : '')}${fact('Progress',game.progress)}${fact('Rating',game.rating ? `${game.rating} / 5` : '')}${fact('Region',game.region)}${fact('Play mode',game.play_mode)}${fact('Wikipedia',game.wikipedia_url)}${fact('Video URL',game.video_url)}
           </div>${game.description ? `<p class="description">${escapeHtml(game.description)}</p>` : ''}${game.notes ? `<p class="description"><strong>Notes</strong><br>${escapeHtml(game.notes)}</p>` : ''}
           ${game.applications.length || game.versions.length || game.documents.length ? `<div class="extras">${game.applications.map((item,index) => `<button class="icon-button" data-extra="applications:${index}">App · ${escapeHtml(item.name)}</button>`).join('')}${game.versions.map((item,index) => `<button class="icon-button" data-extra="versions:${index}">Version · ${escapeHtml(item.name)}</button>`).join('')}${game.documents.map((item,index) => `<button class="icon-button" data-document="${index}">Read ${escapeHtml(item.name)}</button><button class="icon-button" data-extra="documents:${index}" aria-label="Open ${escapeHtml(item.name)} externally">↗</button>`).join('')}</div>` : ''}</div>
           ${game.has_video ? `<div class="detail-card"><h3>Video</h3><video class="media-player" controls preload="metadata" src="${media(game,'video')}"></video></div>` : ''}
           ${game.has_music ? `<div class="detail-card"><h3>Music</h3><audio class="media-player" controls preload="metadata" src="${media(game,'music')}"></audio></div>` : ''}
           ${game.available_screenshots.length ? `<div class="detail-card"><h3>Screenshots</h3><div class="screenshot-grid">${game.available_screenshots.map(index => `<button data-screenshot="${index}" aria-label="Open screenshot ${index + 1}"><img src="${media(game,'screenshot',index)}" alt="" loading="lazy" decoding="async"></button>`).join('')}</div></div>` : ''}
+          ${renderArtwork(game)}
           <div class="detail-card"><h3>Related Games</h3><div class="related-grid" id="relatedGames"><span class="description">Finding matches…</span></div></div>
           ${raConfigured ? `<div class="detail-card"><h3>RetroAchievements</h3><div id="achievementContent"><p class="description">${game.ra_game_id ? `Matched to game ${escapeHtml(game.ra_game_id)}.` : 'Match this ROM to load achievements.'}</p><div class="extras">${game.steam_app_id ? '<button class="icon-button" id="downloadTrailer">Download Steam trailer</button>' : ''}${game.heroic_app_id ? '<button class="icon-button" id="downloadGogMedia">Download GOG media</button>' : ''}<button class="icon-button" id="openBrowser">Open Wikipedia</button></div><button class="icon-button" id="loadAchievements">Load achievements</button><div id="achievementStats"></div></div></div>` : ''}
           <div class="detail-card"><h3>Save management</h3><div class="extras"><button class="icon-button" id="discoverSaves">Discover locations</button>${game.save_paths.length ? '<button class="icon-button" id="backupSaves">Back up now</button>' : ''}<button class="icon-button" id="ludusaviBackup">Ludusavi backup</button><button class="icon-button" id="ludusaviRestore">Ludusavi restore</button>${appSettings.save_tools?.hoard ? '<button class="icon-button" id="hoardBackup">Hoard backup</button>' : ''}${game.platform === 'Arcade' || game.rom_name ? '<button class="icon-button" id="exportHighscores">Export high scores</button>' : ''}</div><div class="description" id="saveDiscovery">${game.save_paths.length ? `${game.save_paths.length} configured location${game.save_paths.length === 1 ? '' : 's'}` : 'No save location configured.'}${appSettings.save_tools?.ludusavi ? ' · Ludusavi detected' : ' · Install ludusavi for automatic save discovery'}</div><div class="extras" id="saveBackups"></div></div>
@@ -1010,6 +1177,15 @@
         $('mediaDialog').append(image);
         $('mediaDialog').showModal();
       });
+      document.querySelectorAll('[data-artwork]').forEach(button => button.onclick = () => {
+        const image = document.createElement('img');
+        image.id = 'fullScreenshot';
+        image.alt = button.getAttribute('aria-label') || 'Game artwork';
+        image.decoding = 'async';
+        image.src = media(game,button.dataset.artwork);
+        $('mediaDialog').append(image);
+        $('mediaDialog').showModal();
+      });
       document.querySelectorAll('[data-document]').forEach(button => button.onclick = () => openReader(game, Number(button.dataset.document)));
       if ($('loadAchievements')) $('loadAchievements').onclick = () => loadAchievements(game.id);
       if ($('downloadTrailer')) $('downloadTrailer').onclick = async () => { try { await api('/api/metadata/trailer',{method:'POST',body:JSON.stringify({id:game.id})}); await refresh(); renderDetails(); notify('Steam trailer downloaded'); } catch(error) { notify(error.message); } };
@@ -1027,17 +1203,32 @@
     }
     async function loadRelated(id) {
       try {
-        const result = await api(`/api/related?id=${id}`);
+        const result = await api(`/api/related/rich?id=${id}`);
         if (!$('relatedGames') || selectedId !== id) return;
-        const related = result.ids.map(gameId => games.find(game => game.id === gameId)).filter(Boolean);
-        $('relatedGames').innerHTML = related.length ? related.map(game => `<button class="related-game" data-related="${game.id}" title="${escapeHtml(game.name)}">${escapeHtml(game.name)}</button>`).join('') : '<span class="description">No related games are in this library yet.</span>';
+        const related = (result.items || []).map(item => ({...item, game:games.find(game => game.id === item.id)})).filter(item => item.game);
+        $('relatedGames').innerHTML = related.length ? related.map(item => `<button class="related-game" data-related="${item.game.id}" title="${escapeHtml(item.reasons.join(', '))}">${escapeHtml(item.game.name)}<small>${escapeHtml(item.reasons.join(' · '))}</small></button>`).join('') : '<span class="description">No related games are in this library yet.</span>';
         document.querySelectorAll('[data-related]').forEach(button => button.onclick = () => selectGame(Number(button.dataset.related)));
       } catch(error) { if ($('relatedGames')) $('relatedGames').textContent = error.message; }
     }
     const fact = (label,value) => `<div class="fact"><small>${label}</small><span>${escapeHtml(value || '-')}</span></div>`;
     function render() { renderPlatformCategories(); renderPlatforms(); renderPlaylists(); renderFilterPresets(); renderGrid(); renderDetails(); applySidebarVisibility(); $('status').textContent = `${games.length} games · local library`; }
+    function collectionStats(items) {
+      const completed = items.filter(game => ['Beaten','Completed','Mastered'].includes(game.progress)).length;
+      const playtime = items.reduce((total, game) => total + Number(game.playtime_seconds || 0), 0);
+      const plays = items.reduce((total, game) => total + Number(game.play_count || 0), 0);
+      return `<div class="collection-summary"><div class="collection-stat"><small>Games</small><strong>${items.length}</strong></div><div class="collection-stat"><small>Completed</small><strong>${completed}</strong></div><div class="collection-stat"><small>Play time</small><strong>${duration(playtime)}</strong></div><div class="collection-stat"><small>Launches</small><strong>${plays}</strong></div><div class="collection-stat"><small>Favorites</small><strong>${items.filter(game => game.favorite).length}</strong></div><div class="collection-stat"><small>Missing files</small><strong>${items.filter(game => !game.path_exists).length}</strong></div></div>`;
+    }
+    function renderCollectionDetails(title, items, kind) {
+      const lastPlayed = [...items].filter(game => game.last_played).sort((a,b) => String(b.last_played).localeCompare(String(a.last_played)))[0];
+      const mostPlayed = [...items].sort((a,b) => Number(b.play_count || 0) - Number(a.play_count || 0))[0];
+      const random = items[Math.floor(Math.random() * items.length)];
+      $('details').innerHTML = `<div class="platform-panel"><div class="hero-kicker">${escapeHtml(kind)}</div><h2>${escapeHtml(title)}</h2><p class="description">${items.length} game${items.length === 1 ? '' : 's'} in this view.</p>${collectionStats(items)}<div class="detail-card"><h3>Quick actions</h3><div class="extras">${random ? `<button class="primary" id="playRandomCollection">Play random</button>` : ''}${lastPlayed ? `<button class="icon-button" data-collection-game="${lastPlayed.id}">Last played · ${escapeHtml(lastPlayed.name)}</button>` : ''}${mostPlayed ? `<button class="icon-button" data-collection-game="${mostPlayed.id}">Most played · ${escapeHtml(mostPlayed.name)}</button>` : ''}</div></div><div class="detail-card"><h3>Featured games</h3><div class="related-grid">${items.slice(0,8).map(game => `<button class="related-game" data-collection-game="${game.id}" title="${escapeHtml(game.name)}">${escapeHtml(game.name)}</button>`).join('') || '<span class="description">No games found.</span>'}</div></div></div>`;
+      if (random) $('playRandomCollection').onclick = () => launch(random.id);
+      document.querySelectorAll('[data-collection-game]').forEach(button => button.onclick = () => selectGame(Number(button.dataset.collectionGame)));
+    }
     async function renderPlatformDetails(platformName) {
       const count = games.filter(game => (game.platform || 'Unspecified') === platformName).length;
+      const items = games.filter(game => (game.platform || 'Unspecified') === platformName);
       let documents = [];
       try {
         const result = await api(`/api/platform/documents?platform=${encodeURIComponent(platformName)}`);
@@ -1045,7 +1236,12 @@
       } catch(error) {
         documents = appSettings.platform_documents?.[platformName] || [];
       }
-      $('details').innerHTML = `<div class="platform-panel"><div class="hero-kicker">Platform</div><h2>${escapeHtml(platformName)}</h2><p class="description">${count} game${count === 1 ? '' : 's'} in this platform view.</p><div class="detail-card"><h3>Platform documents</h3>${documents.length ? `<div class="extras">${documents.map((item,index) => `<button class="icon-button" data-platform-doc="${index}">${escapeHtml(item.name)}</button>`).join('')}</div>` : '<p class="description">No platform documents configured yet.</p>'}<div class="extras"><button class="icon-button" id="editPlatformDocuments">Edit platform documents</button></div></div></div>`;
+      $('details').innerHTML = `<div class="platform-panel"><div class="hero-kicker">Platform</div><h2>${escapeHtml(platformName)}</h2><p class="description">${count} game${count === 1 ? '' : 's'} in this platform view.</p>${collectionStats(items)}<div class="detail-card"><h3>Platform documents</h3>${documents.length ? `<div class="extras">${documents.map((item,index) => `<button class="icon-button" data-platform-doc="${index}">${escapeHtml(item.name)}</button>`).join('')}</div>` : '<p class="description">No platform documents configured yet.</p>'}<div class="extras"><button class="icon-button" id="editPlatformDocuments">Edit platform documents</button></div></div><div class="detail-card"><h3>Platform shortcuts</h3><div class="extras"><button class="primary" id="platformRandom">Play random</button>${items.filter(game => game.last_played).sort((a,b) => String(b.last_played).localeCompare(String(a.last_played)))[0] ? `<button class="icon-button" id="platformLast">Last played</button>` : ''}${items.sort((a,b) => Number(b.play_count || 0) - Number(a.play_count || 0))[0] ? `<button class="icon-button" id="platformMost">Most played</button>` : ''}</div></div></div>`;
+      if (items.length) $('platformRandom').onclick = () => launch(items[Math.floor(Math.random() * items.length)].id);
+      const last = items.filter(game => game.last_played).sort((a,b) => String(b.last_played).localeCompare(String(a.last_played)))[0];
+      const most = [...items].sort((a,b) => Number(b.play_count || 0) - Number(a.play_count || 0))[0];
+      if (last && $('platformLast')) $('platformLast').onclick = () => selectGame(last.id);
+      if (most && $('platformMost')) $('platformMost').onclick = () => selectGame(most.id);
       $('editPlatformDocuments').onclick = async () => {
         const current = (appSettings.platform_documents?.[platformName] || documents).map(item => `${item.name} | ${item.path}`).join('\n');
         const value = prompt(`Platform documents for ${platformName}, one per line: Name | Path`, current);
@@ -1175,6 +1371,7 @@
         tracking_frequency:Number($('trackingFrequency').value),
         auto_close_store_clients:$('autoCloseStoreClients').checked,
         image_group:$('defaultImageGroup').value,
+        badge_visibility:[...document.querySelectorAll('[data-badge-setting]:checked')].map(input => input.dataset.badgeSetting),
         controller_map:Object.fromEntries([...document.querySelectorAll('[data-controller]')].map(input => [input.dataset.controller,Number(input.value)])),
         welcome_completed:appSettings.welcome_completed,
         locale:$('localeSetting').value,
@@ -1219,6 +1416,22 @@
       window.close();
     }
     async function favorite(id) { try { await api('/api/favorite',{method:'POST',body:JSON.stringify({id})}); await refresh(); } catch(error) { notify(error.message); } }
+    function closeContextMenu() { $('contextMenu').hidden = true; contextGameId = null; }
+    function openContextMenu(event, id) {
+      event.preventDefault();
+      contextGameId = id;
+      selectedId = id;
+      const menu = $('contextMenu');
+      $('contextPlaylist').innerHTML = '<option value="">Add to playlist...</option>' + playlists.filter(item => item.type === 'manual').map(item => `<option value="${escapeHtml(item.name)}">${escapeHtml(item.name)}</option>`).join('');
+      menu.hidden = false;
+      menu.style.left = `${Math.min(event.clientX, window.innerWidth - menu.offsetWidth - 8)}px`;
+      menu.style.top = `${Math.min(event.clientY, window.innerHeight - menu.offsetHeight - 8)}px`;
+    }
+    async function updateGameStatus(id, progress) {
+      const game = games.find(item => item.id === id);
+      if (!game) return;
+      try { await api('/api/game',{method:'POST',body:JSON.stringify({id,game:{...game,progress}})}); await refresh(); notify(`Progress set to ${progress || 'Not set'}`); } catch(error) { notify(error.message); }
+    }
     async function removeGame(id,name) {
       if (!confirm(`Remove "${name}" from OpenBox? Game files will not be deleted.`)) return;
       const alsoDeleteMedia = confirm('Also delete associated media files listed in this game entry?');
@@ -1375,6 +1588,13 @@
         }
         return `<label class="field"><span>${escapeHtml(def.name)}</span><input data-custom-field="${escapeHtml(def.name)}" value="${escapeHtml(value)}"></label>`;
       }).join('') : '';
+      const profileSelect = $('gameForm').elements.launch_profile;
+      const platformName = $('gameForm').elements.platform.value.trim();
+      if (profileSelect) {
+        const currentProfile = game?.launch_profile || '';
+        profileSelect.innerHTML = '<option value="">Default platform profile</option>' + Object.keys(availableProfiles).filter(name => !platformName || name === platformName).map(name => `<option value="${escapeHtml(name)}">${escapeHtml(name)}</option>`).join('');
+        profileSelect.value = currentProfile;
+      }
       $('gameDialog').showModal();
     }
     $('gameForm').onsubmit = async event => {
@@ -1457,6 +1677,8 @@
         $('startupCommands').value = (appSettings.startup_commands || []).join('\n');
         $('shutdownCommands').value = (appSettings.shutdown_commands || []).join('\n');
         $('defaultImageGroup').value = appSettings.image_group || 'cover';
+        const visibleBadges = new Set(appSettings.badge_visibility || defaultBadges);
+        document.querySelectorAll('[data-badge-setting]').forEach(input => input.checked = visibleBadges.has(input.dataset.badgeSetting));
         $('trackSessionHistory').checked = appSettings.track_session_history !== false;
         $('backupOnClose').checked = Boolean(appSettings.backup_on_close);
         $('progressAutomationEnabled').checked = Boolean(appSettings.progress_automation_enabled);
@@ -1817,13 +2039,82 @@
     async function saveFilter() {
       const name = prompt('Playlist name', activePlaylist);
       if (!name?.trim()) return;
-      const rules = {platform,view:$('view').value,query:$('sidebarSearch').value.trim()};
+      const rules = {platform,platform_category:platformCategory,view:$('view').value,query:$('sidebarSearch').value.trim(),esrb:$('esrbFilter')?.value || '',progress:explorerRules.progress || ''};
       try {
-        await api('/api/playlists',{method:'POST',body:JSON.stringify({name:name.trim(),rules})});
+        await api('/api/playlists',{method:'POST',body:JSON.stringify({name:name.trim(),type:'filter',rules})});
         activePlaylist = name.trim();
         await refresh();
         notify('Playlist saved');
       } catch(error) { notify(error.message); }
+    }
+    async function saveManualPlaylist(name, members, parent = '', notes = '') {
+      const cleanName = String(name || '').trim();
+      if (!cleanName) return false;
+      try {
+        await api('/api/playlists',{method:'POST',body:JSON.stringify({name:cleanName,type:'manual',rules:{},members,parent,notes})});
+        await refresh();
+        notify('Manual playlist saved');
+        return true;
+      } catch(error) { notify(error.message); return false; }
+    }
+    async function createManualPlaylist(seedId = null) {
+      const name = prompt('Manual playlist name');
+      if (!name?.trim()) return;
+      const parent = prompt('Parent playlist, optional', '') || '';
+      await saveManualPlaylist(name, seedId === null ? [] : [seedId], parent);
+    }
+    async function addGamesToPlaylist(name, ids) {
+      const playlist = playlistFor(name);
+      if (!playlist) return;
+      if (playlist.type !== 'manual') return notify('Filter playlists manage membership from their rules.');
+      const members = [...new Set([...(playlist.members || []), ...ids.map(id => games.find(game => game.id === id)?.game_id || id)])];
+      await saveManualPlaylist(name, members, playlist.parent, playlist.notes);
+    }
+    async function updateManualPlaylist(playlist, members) {
+      await saveManualPlaylist(playlist.name, members, playlist.parent, playlist.notes);
+      openPlaylists();
+    }
+    async function openPlaylists() {
+      $('playlistManagerList').innerHTML = playlists.length ? playlists.map(item => {
+        const members = (item.members || []).map(value => games.find(game => String(game.game_id) === String(value))).filter(Boolean);
+        const memberRows = item.type === 'manual' ? `<div class="member-list">${members.map((game,index) => `<div class="member-row"><span>${escapeHtml(game.name)}</span><button type="button" class="icon-button" data-playlist-name="${escapeHtml(item.name)}" data-playlist-index="${index}" data-playlist-direction="up">↑</button><button type="button" class="icon-button" data-playlist-name="${escapeHtml(item.name)}" data-playlist-index="${index}" data-playlist-direction="down">↓</button></div>`).join('') || '<span class="description">No games yet.</span>'}</div>` : '';
+        return `<div class="playlist-manager-item"><div><strong>${escapeHtml(item.name)}</strong><small>${item.type === 'manual' ? `${members.length} ordered games` : 'Filter playlist'}${item.parent ? ` · under ${escapeHtml(item.parent)}` : ''}</small>${memberRows}</div><div class="playlist-manager-actions"><button type="button" class="icon-button" data-edit-playlist="${escapeHtml(item.name)}">Edit</button><button type="button" class="playlist-delete" data-manager-delete-playlist="${escapeHtml(item.name)}" aria-label="Delete ${escapeHtml(item.name)}">×</button></div></div>`;
+      }).join('') : '<p class="description">No playlists yet.</p>';
+      document.querySelectorAll('[data-manager-delete-playlist]').forEach(button => button.onclick = () => deletePlaylist(button.dataset.managerDeletePlaylist).then(openPlaylists));
+      document.querySelectorAll('[data-edit-playlist]').forEach(button => button.onclick = () => {
+        const item = playlistFor(button.dataset.editPlaylist);
+        if (!item) return;
+        const notes = prompt('Playlist notes', item.notes || '');
+        if (notes === null) return;
+        if (item.type === 'manual') updateManualPlaylist(item, item.members || []);
+        else api('/api/playlists',{method:'POST',body:JSON.stringify({...item,notes})}).then(refresh).then(openPlaylists).catch(error => notify(error.message));
+      });
+      document.querySelectorAll('[data-playlist-index]').forEach(button => button.onclick = () => {
+        const item = playlistFor(button.dataset.playlistName);
+        const index = Number(button.dataset.playlistIndex);
+        if (!item || item.type !== 'manual') return;
+        const members = [...item.members];
+        const target = index + (button.dataset.playlistDirection === 'up' ? -1 : 1);
+        if (target < 0 || target >= members.length) return;
+        [members[index],members[target]] = [members[target],members[index]];
+        updateManualPlaylist(item, members);
+      });
+      if (!$('playlistsDialog').open) $('playlistsDialog').showModal();
+    }
+    async function createFilterPlaylist() { await saveFilter(); openPlaylists(); }
+    async function openBackups() {
+      try {
+        const result = await api('/api/backups');
+        $('backupList').innerHTML = result.backups.length ? result.backups.map(item => `<div class="backup-item"><div><strong>${escapeHtml(item.name)}</strong><small>${escapeHtml(item.created || 'Unknown date')} · ${formatBytes(item.size)} · ${(item.items || []).join(', ') || 'Unknown contents'}</small></div><button type="button" class="icon-button" data-restore-backup="${escapeHtml(item.path)}" ${item.invalid ? 'disabled' : ''}>Restore</button></div>`).join('') : '<p class="description">No backups have been created yet.</p>';
+        document.querySelectorAll('[data-restore-backup]').forEach(button => button.onclick = async () => {
+          if (!confirm('Restore this backup? A safety copy of the current library will be created first.')) return;
+          try { const result = await api('/api/backup/restore',{method:'POST',body:JSON.stringify({path:button.dataset.restoreBackup})}); await refresh(); notify(`Restored ${result.restored.join(', ')}`); } catch(error) { notify(error.message); }
+        });
+        if (!$('backupDialog').open) $('backupDialog').showModal();
+      } catch(error) { notify(error.message); }
+    }
+    async function createNamedBackup() {
+      try { const result = await api('/api/backup/create',{method:'POST',body:JSON.stringify({items:['library','settings','media','plugins','themes'],keep:7})}); notify(`Backup saved to ${result.name}`); openBackups(); } catch(error) { notify(error.message); }
     }
     async function deletePlaylist(name) {
       if (!confirm(`Delete playlist "${name}"?`)) return;
@@ -2342,7 +2633,25 @@
     });
     $('readerPrev').onclick = () => setReaderPage(readerPage - 1);
     $('readerNext').onclick = () => setReaderPage(readerPage + 1);
-    $('addButton').onclick = () => openGameDialog(); $('importButton').onclick = importFolder; $('steamButton').onclick = importSteam; $('heroicButton').onclick = importHeroic; $('lutrisButton').onclick = importLutris; $('arcadeButton').onclick = importArcade; $('emulatorsButton').onclick = openProfiles; $('settingsButton').onclick = openSettings; $('bigBoxButton').onclick = openBigBox; $('sessionsButton').onclick = openSessions; $('historyButton').onclick = openHistory; $('themesButton').onclick = openThemes; $('saveFilterButton').onclick = saveFilter; $('savePresetButton').onclick = savePreset; $('achievementsButton').onclick = openAchievements; $('pluginsButton').onclick = openPlugins; $('mediaButton').onclick = openMediaManager; $('healthButton').onclick = health; $('bulkButton').onclick = bulkAction; $('backupButton').onclick = backup;
+    $('addButton').onclick = () => openGameDialog(); $('importButton').onclick = importFolder; $('steamButton').onclick = importSteam; $('heroicButton').onclick = importHeroic; $('lutrisButton').onclick = importLutris; $('arcadeButton').onclick = importArcade; $('emulatorsButton').onclick = openProfiles; $('settingsButton').onclick = openSettings; $('bigBoxButton').onclick = openBigBox; $('sessionsButton').onclick = openSessions; $('historyButton').onclick = openHistory; $('themesButton').onclick = openThemes; $('saveFilterButton').onclick = saveFilter; $('savePresetButton').onclick = savePreset; $('playlistsButton').onclick = openPlaylists; $('achievementsButton').onclick = openAchievements; $('pluginsButton').onclick = openPlugins; $('mediaButton').onclick = openMediaManager; $('healthButton').onclick = health; $('bulkButton').onclick = bulkAction; $('backupButton').onclick = openBackups;
+    $('closePlaylists').onclick = $('donePlaylists').onclick = () => $('playlistsDialog').close();
+    $('newManualPlaylist').onclick = () => createManualPlaylist();
+    $('newFilterPlaylist').onclick = createFilterPlaylist;
+    $('closeBackups').onclick = $('doneBackups').onclick = () => $('backupDialog').close();
+    $('refreshBackups').onclick = openBackups;
+    $('createNamedBackup').onclick = createNamedBackup;
+    $('contextPlay').onclick = () => { const id = contextGameId; closeContextMenu(); if (id !== null) launch(id); };
+    $('contextFavorite').onclick = () => { const id = contextGameId; closeContextMenu(); if (id !== null) favorite(id); };
+    $('contextEdit').onclick = () => { const game = games.find(item => item.id === contextGameId); closeContextMenu(); if (game) openGameDialog(game); };
+    $('contextProgress').onclick = () => { const id = contextGameId; closeContextMenu(); if (id === null) return; const value = prompt('Progress value', games.find(game => game.id === id)?.progress || 'Playing'); if (value !== null) updateGameStatus(id, value); };
+    $('contextAddPlaylist').onclick = () => { const name = $('contextPlaylist').value; const id = contextGameId; closeContextMenu(); if (name && id !== null) addGamesToPlaylist(name, [id]); };
+    $('contextNewPlaylist').onclick = () => { const id = contextGameId; closeContextMenu(); if (id !== null) createManualPlaylist(id); };
+    $('contextRemove').onclick = () => { const game = games.find(item => item.id === contextGameId); closeContextMenu(); if (game) removeGame(game.id, game.name); };
+    document.addEventListener('contextmenu', event => {
+      const target = event.target.closest?.('[data-game]');
+      if (target) openContextMenu(event, Number(target.dataset.game));
+    });
+    document.addEventListener('click', event => { if (!event.target.closest?.('#contextMenu')) closeContextMenu(); });
     if ($('scanEmulatorFolder')) $('scanEmulatorFolder').onclick = async () => {
       const folder = $('emulatorScanFolder').value.trim();
       if (!folder) return notify('Enter a ROM folder path first.');

--- a/openbox.metainfo.xml
+++ b/openbox.metainfo.xml
@@ -15,6 +15,13 @@
   <url type="bugtracker">https://github.com/vindeckyy/OpenBoxGL/issues</url>
   <url type="vcs-browser">https://github.com/vindeckyy/OpenBoxGL</url>
   <releases>
+    <release version="0.6.0" date="2026-07-30">
+      <description>
+        <p>The Web UI adds LaunchBox-style advanced search, ordered manual playlists with parent grouping, context actions, Ctrl and Shift multi-selection, configurable status badges, richer collection details, related-game reasons, artwork galleries, and per-game launch profile overrides.</p>
+        <p>Backup archives can be listed, inspected, and restored from the Web UI. Extended artwork groups cover clear logos, fanart, banners, icons, box backs, box spines, 3D boxes, and title screens. Game metadata now includes controller support, disc count, portable status, and broken-entry flags.</p>
+        <p>Backend hardening adds schema migrations, stable game identities, recovery and atomic persistence, bounded jobs and I/O, safer archive and restore paths, stricter packaging checks, focused regression tests, and verified Chromium coverage for the new workflows.</p>
+      </description>
+    </release>
     <release version="0.5.0" date="2026-07-30">
       <description>
         <p>Steam Game Mode guest support runs Big Box inside gamescope on Steam Deck and similar handhelds, while Steam keeps Input and Quick Access Menu controls. Settings can now remove all Steam-imported library entries at once without deleting game files or media.</p>

--- a/test_packaging.py
+++ b/test_packaging.py
@@ -169,7 +169,7 @@ def test_legal_policy():
     assert "clean-room" not in disclaimer
     assert "15 U.S.C." not in disclaimer
     assert "Openbox window manager" in trademarks
-    assert "| 0.5.x | Yes |" in security
+    assert "| 0.6.x | Yes |" in security
     assert "| < 0.4.0 | No |" in security
     print("  Legal policy: ok")
 

--- a/test_parity_api.py
+++ b/test_parity_api.py
@@ -369,6 +369,71 @@ class ParityApiTests(unittest.TestCase):
         self.assertEqual(settings["gameyfin_password"], "secret")
         self.assertEqual(settings["gameyfin_install_dir"], "/tmp/gameyfin")
 
+    def test_manual_playlist_preserves_order_and_metadata(self):
+        from openbox import load_state, save_state
+        from web_app import Handler
+
+        save_state({
+            "games": [
+                {"name": "Alpha", "game_id": "game-alpha", "path": "/bin/true"},
+                {"name": "Beta", "game_id": "game-beta", "path": "/bin/true"},
+            ],
+            "profiles": {}, "history": [], "settings": {}, "playlists": [],
+        })
+        handler = object.__new__(Handler)
+        handler.send_json = mock.Mock()
+        Handler.save_playlist(handler, {
+            "name": "Weekend order",
+            "type": "manual",
+            "members": [1, 0, 1],
+            "parent": "Favorites",
+            "notes": "Play in this order",
+            "rules": {},
+        })
+        state = load_state()
+        playlist = state["playlists"][0]
+        self.assertEqual(playlist["type"], "manual")
+        self.assertEqual(playlist["members"], [state["games"][1]["game_id"], state["games"][0]["game_id"]])
+        self.assertEqual(playlist["parent"], "Favorites")
+        self.assertEqual(playlist["notes"], "Play in this order")
+
+    def test_settings_save_persists_badges_and_extended_image_group(self):
+        from openbox import load_state, save_state
+        from web_app import Handler
+
+        save_state({"games": [], "profiles": {}, "history": [], "settings": {}, "playlists": []})
+        handler = object.__new__(Handler)
+        handler.send_json = mock.Mock()
+        Handler.save_settings(handler, {
+            "watch_folders": [],
+            "image_group": "fanart",
+            "badge_visibility": ["favorite", "missing_media", "controller"],
+        })
+        settings = load_state()["settings"]
+        self.assertEqual(settings["image_group"], "fanart")
+        self.assertEqual(settings["badge_visibility"], ["favorite", "missing_media", "controller"])
+
+    def test_backup_listing_reports_created_manifest(self):
+        from openbox import load_state, save_state
+        from web_app import Handler
+
+        save_state({"games": [], "profiles": {}, "history": [], "settings": {}, "playlists": []})
+        create_handler = object.__new__(Handler)
+        create_handler.send_json = mock.Mock()
+        Handler.create_library_backup(create_handler, {"items": ["library", "settings"], "keep": 7})
+
+        list_handler = object.__new__(Handler)
+        list_handler.authorized = mock.Mock(return_value=True)
+        list_handler.send_json = mock.Mock()
+        list_handler.do_GET = Handler.do_GET.__get__(list_handler, Handler)
+        list_handler.path = "/api/backups"
+        list_handler.headers = {}
+        list_handler.do_GET()
+        status, payload = list_handler.send_json.call_args[0]
+        self.assertEqual(status, 200)
+        self.assertTrue(payload["backups"])
+        self.assertIn(["library", "settings"], [item["items"] for item in payload["backups"]])
+
     def test_local_plugin_catalog_file(self):
         catalog = load_local_catalog()
         self.assertTrue(any(item.get("id") == "openbox.library-stats" for item in catalog))

--- a/test_parity_features.py
+++ b/test_parity_features.py
@@ -4,6 +4,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from parity_discovery import discovery_lists, item_rating
 from parity_import import generate_m3u, group_multi_disc, recommend_emulators
@@ -84,6 +85,26 @@ class ParityFeatureTests(unittest.TestCase):
         self.assertEqual(lists["recently_added"][0], 0)
         self.assertEqual(lists["never_played"][0], 0)
         self.assertEqual(item_rating(games[0]), 5.0)
+
+    def test_launch_profile_override(self):
+        with tempfile.TemporaryDirectory() as folder:
+            path = Path(folder) / "game.sh"
+            path.write_text("#!/bin/sh\n")
+            import web_app
+            from openbox import save_state
+            save_state({
+                "games": [{"name": "Profile test", "platform": "Linux", "path": str(path), "launch_profile": "handheld"}],
+                "profiles": {"Linux": "default {path}", "handheld": "custom {path}"},
+                "history": [], "settings": {}, "playlists": [],
+            })
+            process = type("Process", (), {"pid": 1234, "wait": lambda self: 0, "poll": lambda self: 0})()
+            with tempfile.TemporaryDirectory() as cwd:
+                with mock.patch("web_app.subprocess.Popen", return_value=process) as popen:
+                    with mock.patch("web_app.build_launch", return_value=(["custom", str(path)], cwd)) as build:
+                        web_app.start_game(0)
+            build.assert_called_once()
+            self.assertEqual(build.call_args.args[1], {"Linux": "custom {path}"})
+            popen.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/updates.py
+++ b/updates.py
@@ -9,7 +9,7 @@ from urllib.request import Request, urlopen
 
 from backend_io import atomic_write_bytes, atomic_write_text, download_file, read_limited
 
-VERSION = "0.5.0"
+VERSION = "0.6.0"
 RELEASE_API = "https://api.github.com/repos/vindeckyy/OpenBoxGL/releases/latest"
 ASSET = "OpenBox-x86_64.AppImage"
 TRUSTED_RELEASE_PREFIX = "https://github.com/vindeckyy/OpenBoxGL/releases/download/"

--- a/web_app.py
+++ b/web_app.py
@@ -132,12 +132,14 @@ WATCH_STOP = threading.Event()
 METADATA_DATABASE = DATA.parent / "metadata/launchbox.db"
 FIELDS = {
     "name", "platform", "genre", "year", "developer", "publisher", "series",
-    "collection", "description", "path", "launch", "cover", "background",
+    "collection", "description", "path", "launch", "launch_profile", "cover", "background",
+    "clear_logo", "fanart", "banner", "icon", "box_back", "box_spine", "box_3d", "title_screen",
     "source", "steam_app_id", "lutris_id", "install_dir",
     "heroic_app_id", "rom_name", "clone_of", "set_type", "ra_game_id", "ra_hash", "launchbox_db_id", "archive_member", "video", "music",
     "video_snap", "video_theme", "video_trailer", "video_recording",
     "progress", "rating", "notes", "region", "play_mode", "sort_title", "added_at",
     "alternate_names", "max_players", "wikipedia_url", "video_url", "hide_in_bigbox", "esrb",
+    "broken", "portable", "controller_support", "disc_count",
     "gameyfin_id", "gameyfin_provider", "store_catalog", "store_installed", "owned",
     "tracking_mode", "tracking_delay", "tracking_frequency", "tracking_process_name", "igdb_id",
 }
@@ -349,6 +351,7 @@ def public_settings(state=None):
         "watch_folders": settings.get("watch_folders", []),
         "screensaver_seconds": settings.get("screensaver_seconds", 90),
         "controller_map": settings.get("controller_map", {}),
+        "badge_visibility": settings.get("badge_visibility", ["favorite", "installed", "saves", "documents", "progress", "storefront", "achievements", "rating"]),
         "image_group": settings.get("image_group", "cover"),
         "image_group_by_platform": settings.get("image_group_by_platform", {}),
         "image_group_by_playlist": settings.get("image_group_by_playlist", {}),
@@ -438,11 +441,23 @@ def public_state():
             "path_exists": path_exists,
             "has_cover": probe_path(game.get("cover"), file_only=True),
             "has_background": probe_path(game.get("background"), file_only=True),
+            "has_clear_logo": probe_path(game.get("clear_logo"), file_only=True),
+            "has_fanart": probe_path(game.get("fanart"), file_only=True),
+            "has_banner": probe_path(game.get("banner"), file_only=True),
+            "has_icon": probe_path(game.get("icon"), file_only=True),
+            "has_box_back": probe_path(game.get("box_back"), file_only=True),
+            "has_box_spine": probe_path(game.get("box_spine"), file_only=True),
+            "has_box_3d": probe_path(game.get("box_3d"), file_only=True),
+            "has_title_screen": probe_path(game.get("title_screen"), file_only=True),
             "has_video": bool(video_path),
             "active_video_field": video_field,
             "has_music": probe_path(game.get("music"), file_only=True),
             "has_saves": index in save_indices or bool(game.get("save_paths")),
             "has_documents": bool(game.get("documents")),
+            "has_versions": bool(game.get("versions")),
+            "has_achievements": bool(game.get("ra_game_id")),
+            "has_highscores": bool(game.get("rom_name")) and str(game.get("platform", "")).casefold() in {"arcade", "mame", "finalburn neo"},
+            "has_missing_media": not probe_path(game.get("cover"), file_only=True),
             "extract_archive": bool(game.get("extract_archive")),
             "applications": game.get("applications", []),
             "versions": game.get("versions", []),
@@ -727,6 +742,9 @@ def start_game(index=None, stable_game_id=""):
     game = copy.deepcopy(state["games"][index])
     stable_game_id = str(game.get("game_id") or stable_game_id)
     profiles = dict(state["profiles"])
+    selected_profile = str(game.get("launch_profile", "")).strip()
+    if selected_profile and selected_profile in profiles:
+        profiles = {game.get("platform", ""): profiles[selected_profile]}
     args, cwd = build_launch(game, profiles)
     if not os.environ.get("OPENBOX_SAFE_MODE"):
         result = run_plugins(DATA.parent / "plugins", "before_launch", {"game": game, "args": args, "cwd": cwd})
@@ -1194,7 +1212,7 @@ class Handler(BaseHTTPRequestHandler):
                 if kind == "screenshot":
                     index = int(query["index"][0])
                     media = Path(game.get("screenshots", [])[index])
-                elif kind in {"cover", "background", "video", "music", "video_snap", "video_theme", "video_trailer", "video_recording"}:
+                elif kind in {"cover", "background", "clear_logo", "fanart", "banner", "icon", "box_back", "box_spine", "box_3d", "title_screen", "video", "music", "video_snap", "video_theme", "video_trailer", "video_recording"}:
                     if kind == "video":
                         _, video_path = active_video(game)
                         media = Path(video_path or game.get("video", ""))
@@ -1460,6 +1478,28 @@ class Handler(BaseHTTPRequestHandler):
                 return
             self.send_json(200, {"items": sorted(BACKUP_ITEMS)})
             return
+        if parsed.path == "/api/backups":
+            if not self.authorized():
+                self.send_json(403, {"error": "Unauthorized"})
+                return
+            folder = DATA.parent / "backups"
+            backups = []
+            for path in sorted(folder.glob("OpenBoxBackup-*.zip"), key=lambda item: item.stat().st_mtime, reverse=True):
+                try:
+                    with zipfile.ZipFile(path) as package:
+                        manifest = json.loads(package.read("manifest.json")) if "manifest.json" in package.namelist() else {}
+                except (OSError, zipfile.BadZipFile, KeyError, json.JSONDecodeError):
+                    manifest = {"items": [], "invalid": True}
+                backups.append({
+                    "name": path.name,
+                    "path": str(path),
+                    "size": path.stat().st_size,
+                    "created": manifest.get("created", ""),
+                    "items": manifest.get("items", []),
+                    "invalid": bool(manifest.get("invalid")),
+                })
+            self.send_json(200, {"backups": backups})
+            return
         self.send_json(404, {"error": "Not found"})
 
     def _do_POST(self):
@@ -1693,6 +1733,13 @@ class Handler(BaseHTTPRequestHandler):
         game = {key: str(source[key]).strip() for key in FIELDS if key in source}
         game["extract_archive"] = bool(source.get("extract_archive"))
         game["hidden"] = bool(source.get("hidden"))
+        for field in ("broken", "portable"):
+            game[field] = bool(source.get(field))
+        if "disc_count" in source:
+            try:
+                game["disc_count"] = max(0, int(source.get("disc_count") or 0))
+            except (TypeError, ValueError) as error:
+                raise ValueError("Disc count must be a number.") from error
         if game.get("progress", "") not in PROGRESS:
             raise ValueError("Unknown progress value.")
         try:
@@ -2075,8 +2122,12 @@ class Handler(BaseHTTPRequestHandler):
             raise ValueError("Progress automation idle days must be between 0 and 3650.")
         welcome_completed = bool(merged.get("welcome_completed", False))
         image_group = str(merged.get("image_group", "cover"))
-        if image_group not in {"cover", "background", "screenshot"}:
+        if image_group not in {"cover", "background", "screenshot", "clear_logo", "fanart", "banner", "icon", "box_back", "box_spine", "box_3d", "title_screen"}:
             raise ValueError("Unknown default image group.")
+        badge_visibility = merged.get("badge_visibility", ["favorite", "installed", "saves", "documents", "progress", "storefront", "achievements", "rating"])
+        allowed_badges = {"favorite", "installed", "missing_media", "saves", "documents", "versions", "storefront", "achievements", "highscores", "progress", "rating", "broken", "portable", "controller"}
+        if not isinstance(badge_visibility, list) or not set(badge_visibility) <= allowed_badges:
+            raise ValueError("Badge visibility must contain known badge names.")
         save_backup_limit = int(merged.get("save_backup_limit", 10))
         if not 0 <= save_backup_limit <= 500:
             raise ValueError("Save backup limit must be between 0 and 500.")
@@ -2147,6 +2198,7 @@ class Handler(BaseHTTPRequestHandler):
                 "watch_folders": clean_folders,
                 "screensaver_seconds": seconds,
                 "controller_map": clean_mapping,
+                "badge_visibility": [str(item) for item in badge_visibility],
                 "cloud_folder": cloud_folder,
                 "startup_commands": startup_commands,
                 "shutdown_commands": shutdown_commands,
@@ -2209,7 +2261,7 @@ class Handler(BaseHTTPRequestHandler):
         group = str(payload.get("group", ""))
         scope = str(payload.get("scope", "global"))
         name = str(payload.get("name", "")).strip()
-        if group not in {"default", "cover", "background", "screenshot"} or scope not in {"global", "platform", "playlist"}:
+        if group not in {"default", "cover", "background", "screenshot", "clear_logo", "fanart", "banner", "icon", "box_back", "box_spine", "box_3d", "title_screen"} or scope not in {"global", "platform", "playlist"}:
             raise ValueError("Unknown image group.")
         if scope != "global" and (not name or len(name) > 200):
             raise ValueError("A platform or playlist is required.")
@@ -2455,18 +2507,37 @@ class Handler(BaseHTTPRequestHandler):
         rules = payload.get("rules", {})
         if not name or not isinstance(rules, dict):
             raise ValueError("Playlist name and rules are required.")
+        playlist_type = str(payload.get("type", "filter")).strip().casefold()
+        if playlist_type not in {"filter", "manual"}:
+            raise ValueError("Playlist type must be filter or manual.")
+        state = load_state()
         clean = {
             key: str(rules.get(key, "")).strip()
-            for key in ("platform", "view", "query")
+            for key in ("platform", "view", "query", "platform_category", "esrb", "progress", "genre", "developer", "publisher", "installed", "hidden", "favorite")
             if str(rules.get(key, "")).strip()
         }
+        members = payload.get("members", payload.get("ids", []))
+        if not isinstance(members, list) or len(members) > 100000:
+            raise ValueError("Playlist members must be a list.")
+        member_ids = []
+        for value in members:
+            game = game_from_payload(state, {"game_id": value}) if str(value).startswith("game-") else game_from_payload(state, {"id": value})
+            stable_id = str(game.get("game_id") or "")
+            if stable_id and stable_id not in member_ids:
+                member_ids.append(stable_id)
+        parent = str(payload.get("parent", "")).strip()
+        notes = str(payload.get("notes", "")).strip()
         def mutate(state):
             playlists = state.setdefault("playlists", [])
             existing = next((item for item in playlists if item.get("name") == name), None)
             if existing:
                 existing["rules"] = clean
+                existing["type"] = playlist_type
+                existing["members"] = member_ids if playlist_type == "manual" else []
+                existing["parent"] = parent
+                existing["notes"] = notes
             else:
-                playlists.append({"name": name, "rules": clean})
+                playlists.append({"name": name, "type": playlist_type, "rules": clean, "members": member_ids if playlist_type == "manual" else [], "parent": parent, "notes": notes})
         transact_state(mutate)
         self.send_json(200, {"saved": name})
 


### PR DESCRIPTION
## What changed

- Add advanced search syntax, ordered manual playlists, context actions, Ctrl and Shift selection, configurable badges, collection details, rich related games, expanded artwork groups, backup management, and per-game launch profile overrides.
- Harden backend persistence, jobs, I/O validation, restore paths, and packaging metadata.
- Add API and launch-profile regression coverage plus release and parity documentation.

## Verification

- `./run_all_tests.sh`
- Python compilation
- Web UI JavaScript syntax check
- Chromium smoke test with no page errors

Release target: `v0.6.0`.