### PR TITLE
chore: keep CodeQL action updates in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
   - package-ecosystem: "npm"
     directory: "/scripts"
     schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,14 +40,14 @@ jobs:
           python-version: "3.12"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f3712979fa5f215279b101dd0a2e3bdfb4353324 # github/codeql-action@v3 (v3.37.7)
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # github/codeql-action@v4 (v4.37.7)
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f3712979fa5f215279b101dd0a2e3bdfb4353324 # github/codeql-action@v3 (v3.37.7)
+        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # github/codeql-action@v4 (v4.37.7)
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324 # github/codeql-action@v3 (v3.37.7)
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # github/codeql-action@v4 (v4.37.7)
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Keep all CodeQL action steps on v4.37.7 and group the CodeQL action components in Dependabot.

Fixes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor or maintenance
- [x] Packaging or CI change

## Test plan

- [x] `./run_all_tests.sh`
- [ ] Manual UI verification
- [ ] AppImage or packaging check

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I updated documentation when user-facing behavior changed
- [x] I added or updated tests when behavior changed
- [x] I did not commit secrets, tokens, ROMs, or personal library data
- [x] My commit messages describe the change clearly

## Screenshots or recordings

Not applicable.